### PR TITLE
长按增加或者减少按钮的timer间隔时间过短,用户单击时经常出现+2或-2的情况,TimeInterval加长到0.2能有效的避免这种情况

### DIFF
--- a/PPNumberButton/PPNumberButton/PPNumberButton.m
+++ b/PPNumberButton/PPNumberButton/PPNumberButton.m
@@ -146,11 +146,11 @@
     
     if (sender == _increaseBtn)
     {
-        _timer = [NSTimer scheduledTimerWithTimeInterval:0.1f target:self selector:@selector(increase) userInfo:nil repeats:YES];
+        _timer = [NSTimer scheduledTimerWithTimeInterval:0.2f target:self selector:@selector(increase) userInfo:nil repeats:YES];
     }
     else
     {
-        _timer = [NSTimer scheduledTimerWithTimeInterval:0.1f target:self selector:@selector(decrease) userInfo:nil repeats:YES];
+        _timer = [NSTimer scheduledTimerWithTimeInterval:0.2f target:self selector:@selector(decrease) userInfo:nil repeats:YES];
     }
     [_timer fire];
 }


### PR DESCRIPTION
长按增加或者减少按钮的timer间隔时间过短,用户单击时经常出现+2或-2的情况,TimeInterval加长到0.2能有效的避免这种情况.